### PR TITLE
design: strengthen the portfolio rail

### DIFF
--- a/src/components/site/Rail.tsx
+++ b/src/components/site/Rail.tsx
@@ -10,14 +10,14 @@ export function Rail({ children }: RailProps) {
   const rest = tail.join(" ");
 
   return (
-    <div className="mx-auto grid min-h-screen max-w-[1440px] grid-cols-1 min-[900px]:grid-cols-[330px_minmax(0,1fr)]">
-      <header className="border-b border-border px-4 pb-0 pt-8 min-[360px]:px-5 min-[900px]:sticky min-[900px]:top-0 min-[900px]:col-start-1 min-[900px]:row-start-1 min-[900px]:grid min-[900px]:h-screen min-[900px]:grid-rows-[auto_minmax(0,1fr)_9rem] min-[900px]:overflow-y-auto min-[900px]:border-b-0 min-[900px]:border-r min-[900px]:p-11 min-[900px]:px-9">
+    <div className="mx-auto grid min-h-screen max-w-[1440px] grid-cols-1 min-[900px]:grid-cols-[288px_minmax(0,1fr)]">
+      <header className="border-b border-border px-4 pb-0 pt-8 min-[360px]:px-5 min-[900px]:sticky min-[900px]:top-0 min-[900px]:col-start-1 min-[900px]:row-start-1 min-[900px]:grid min-[900px]:h-screen min-[900px]:grid-rows-[auto_minmax(0,1fr)_9rem] min-[900px]:overflow-y-auto min-[900px]:border-b-0 min-[900px]:border-r min-[900px]:p-11 min-[900px]:px-5">
         <div>
           <p className="text-lg font-bold leading-tight tracking-tight">
             {first}
-            {/* A single-word name leaves nothing for the second line, and an
-                empty span is a node no test can address. */}
-            {rest && <span className="block text-text-muted">{rest}</span>}
+            {rest && (
+              <span className="text-text-muted">{` ${rest}`}</span>
+            )}
           </p>
           <p className="mt-3.5 font-mono text-xs uppercase leading-relaxed tracking-[0.12em] text-text-subtle [overflow-wrap:anywhere]">
             {profile.role}
@@ -30,12 +30,12 @@ export function Rail({ children }: RailProps) {
           aria-label="Sections"
           className="mt-5 min-[900px]:row-start-2 min-[900px]:mt-0 min-[900px]:self-center"
         >
-          <ul className="flex flex-nowrap gap-x-2 min-[360px]:gap-x-[18px] min-[900px]:flex-col min-[900px]:gap-5">
+          <ul className="flex w-full flex-nowrap justify-between min-[900px]:flex-col min-[900px]:justify-start min-[900px]:gap-3">
             {profile.navigation.map((section) => (
-              <li key={section.href}>
+              <li key={section.href} className="min-[900px]:w-full">
                 <Link
                   href={section.href}
-                  className="relative flex min-h-11 w-fit items-center gap-0 whitespace-nowrap font-mono text-xs uppercase tracking-[0.12em] text-text-muted transition-colors duration-200 before:absolute before:bottom-1 before:left-0 before:h-px before:w-0 before:bg-accent before:transition-[width] before:duration-200 hover:text-text hover:before:w-5 focus-visible:text-text focus-visible:before:w-5 min-[900px]:min-h-0 min-[900px]:transition-[color,gap] min-[900px]:before:static min-[900px]:hover:gap-3 min-[900px]:focus-visible:gap-3"
+                  className="relative flex min-h-11 w-fit items-center gap-0 whitespace-nowrap font-mono text-sm font-bold uppercase tracking-[0.12em] text-text-muted transition-colors duration-200 before:absolute before:bottom-1 before:left-0 before:h-px before:w-0 before:bg-accent before:transition-[width] before:duration-200 hover:text-text hover:before:w-5 focus-visible:text-text focus-visible:before:w-5 min-[900px]:min-h-10 min-[900px]:w-full min-[900px]:transition-[color,gap] min-[900px]:before:static min-[900px]:hover:gap-3 min-[900px]:focus-visible:gap-3"
                 >
                   {section.label}
                 </Link>
@@ -53,7 +53,7 @@ export function Rail({ children }: RailProps) {
         {children}
       </main>
 
-      <footer className="mt-14 border-t border-text px-4 pb-10 pt-7 min-[360px]:px-5 min-[900px]:sticky min-[900px]:top-[calc(100vh-9rem)] min-[900px]:z-10 min-[900px]:col-start-1 min-[900px]:row-start-1 min-[900px]:mt-0 min-[900px]:self-start min-[900px]:border-r min-[900px]:border-t-0 min-[900px]:bg-bg min-[900px]:px-9 min-[900px]:pb-11 min-[900px]:pt-8">
+      <footer className="mt-14 border-t border-text px-4 pb-10 pt-7 min-[360px]:px-5 min-[900px]:sticky min-[900px]:top-[calc(100vh-9rem)] min-[900px]:z-10 min-[900px]:col-start-1 min-[900px]:row-start-1 min-[900px]:mt-0 min-[900px]:self-start min-[900px]:border-r min-[900px]:border-t-0 min-[900px]:bg-bg min-[900px]:px-5 min-[900px]:pb-11 min-[900px]:pt-8">
         <h2 className="mb-3.5 font-mono text-xs uppercase tracking-[0.12em] min-[900px]:sr-only">
           Contact
         </h2>

--- a/src/components/site/Rail.tsx
+++ b/src/components/site/Rail.tsx
@@ -13,7 +13,10 @@ export function Rail({ children }: RailProps) {
     <div className="mx-auto grid min-h-screen max-w-[1440px] grid-cols-1 min-[900px]:grid-cols-[288px_minmax(0,1fr)]">
       <header className="border-b border-border px-4 pb-0 pt-8 min-[360px]:px-5 min-[900px]:sticky min-[900px]:top-0 min-[900px]:col-start-1 min-[900px]:row-start-1 min-[900px]:grid min-[900px]:h-screen min-[900px]:grid-rows-[auto_minmax(0,1fr)_9rem] min-[900px]:overflow-y-auto min-[900px]:border-b-0 min-[900px]:border-r min-[900px]:p-11 min-[900px]:px-5">
         <div>
-          <p className="text-lg font-bold leading-tight tracking-tight">
+          <p
+            data-testid="profile-name"
+            className="whitespace-nowrap text-lg font-bold leading-tight tracking-tight"
+          >
             {first}
             {rest && (
               <span className="text-text-muted">{` ${rest}`}</span>
@@ -35,7 +38,7 @@ export function Rail({ children }: RailProps) {
               <li key={section.href} className="min-[900px]:w-full">
                 <Link
                   href={section.href}
-                  className="relative flex min-h-11 w-fit items-center gap-0 whitespace-nowrap font-mono text-sm font-bold uppercase tracking-[0.12em] text-text-muted transition-colors duration-200 before:absolute before:bottom-1 before:left-0 before:h-px before:w-0 before:bg-accent before:transition-[width] before:duration-200 hover:text-text hover:before:w-5 focus-visible:text-text focus-visible:before:w-5 min-[900px]:min-h-10 min-[900px]:w-full min-[900px]:transition-[color,gap] min-[900px]:before:static min-[900px]:hover:gap-3 min-[900px]:focus-visible:gap-3"
+                  className="relative flex min-h-11 w-fit items-center gap-0 whitespace-nowrap font-mono text-xs font-bold uppercase tracking-[0.12em] text-text-muted transition-colors duration-200 before:absolute before:bottom-1 before:left-0 before:h-px before:w-0 before:bg-accent before:transition-[width] before:duration-200 hover:text-text hover:before:w-5 focus-visible:text-text focus-visible:before:w-5 min-[360px]:text-sm min-[900px]:min-h-10 min-[900px]:w-full min-[900px]:transition-[color,gap] min-[900px]:before:static min-[900px]:hover:gap-3 min-[900px]:focus-visible:gap-3"
                 >
                   {section.label}
                 </Link>

--- a/tests/component/Rail.test.tsx
+++ b/tests/component/Rail.test.tsx
@@ -26,18 +26,13 @@ describe("Rail", () => {
     );
   });
 
-  it("splits the profile name across two lines", () => {
-    const [first, ...tail] = profile.name.split(" ");
-    const rest = tail.join(" ");
+  it("renders the profile name as one complete phrase", () => {
+    const [first] = profile.name.split(" ");
     render(<Rail />);
 
-    const firstLine = screen.getByText(first, { selector: "p" });
-    const secondLine = screen.getByText(rest);
+    const name = screen.getByText(first, { selector: "p" });
 
-    // Whether the second line renders as a block is a styling choice jsdom
-    // cannot observe, and AGENTS.md forbids reaching for the class name to
-    // check it. The containment above is the part that carries meaning.
-    expect(firstLine.contains(secondLine)).toBe(true);
+    expect(name.textContent).toBe(profile.name);
   });
 
   it("shows profile positioning", () => {

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -294,17 +294,19 @@ test.describe("responsive layout", () => {
     page,
   }) => {
     for (const width of [320, 900]) {
-      await page.setViewportSize({ width, height: 800 });
-      await page.goto("/");
+      await test.step(`${width}px viewport`, async () => {
+        await page.setViewportSize({ width, height: 800 });
+        await page.goto("/");
 
-      const name = page.getByTestId("profile-name");
-      const dimensions = await name.evaluate((element) => ({
-        height: element.getBoundingClientRect().height,
-        lineHeight: Number.parseFloat(getComputedStyle(element).lineHeight),
-      }));
+        const name = page.getByTestId("profile-name");
+        const dimensions = await name.evaluate((element) => ({
+          height: element.getBoundingClientRect().height,
+          lineHeight: Number.parseFloat(getComputedStyle(element).lineHeight),
+        }));
 
-      expect(await name.textContent()).toBe("Josh Van Lente");
-      expect(dimensions.height).toBeCloseTo(dimensions.lineHeight, 0);
+        expect(await name.textContent()).toBe("Josh Van Lente");
+        expect(dimensions.height).toBeCloseTo(dimensions.lineHeight, 0);
+      });
     }
   });
 

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -290,6 +290,24 @@ test.describe("content evidence and navigation", () => {
 });
 
 test.describe("responsive layout", () => {
+  test("the profile name stays on one line across rail layouts", async ({
+    page,
+  }) => {
+    for (const width of [320, 900]) {
+      await page.setViewportSize({ width, height: 800 });
+      await page.goto("/");
+
+      const name = page.getByTestId("profile-name");
+      const dimensions = await name.evaluate((element) => ({
+        height: element.getBoundingClientRect().height,
+        lineHeight: Number.parseFloat(getComputedStyle(element).lineHeight),
+      }));
+
+      expect(await name.textContent()).toBe("Josh Van Lente");
+      expect(dimensions.height).toBeCloseTo(dimensions.lineHeight, 0);
+    }
+  });
+
   test("a 120-character work title cannot create horizontal overflow", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- Reduce the desktop identity rail from 330px to 288px and trim its horizontal inset to 20px.
- Give the three section links bold, full-width targets while preserving a safe 12px size at the 320px viewport.
- Keep Josh Van Lente on one line and cover the behavior at 320px and the 900px rail breakpoint.

## Test plan
- [x] `CHOKIDAR_USEPOLLING=1 npm run test -- --reporter=dot` — 264 tests passed
- [x] `npm run lint`
- [x] `npm run build -- --webpack`
- [x] `npm run typecheck`
- [x] `npm run e2e` — 21 tests passed
- [x] Verify the local preview at 320px, 900px, and desktop widths with no horizontal overflow or browser errors

## Review
- Three-model review converged with no remaining actionable findings.
- Final pull request gate review returned no findings.