### PR TITLE
design: align wide-screen rail inset

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,21 @@
+## Design Context
+
+### Users
+
+The primary user is a hiring manager or product leader scanning Josh Van Lente's portfolio under time pressure. The page should communicate his name, staff-level product positioning, attributed outcomes, and credible case-study evidence within 20 seconds.
+
+### Brand Personality
+
+Evidence-led, editorial, and exacting. The interface should feel confident and deliberate, with enough restraint that the work and its outcomes carry the authority.
+
+### Aesthetic Direction
+
+Use a dark-only, editorial portfolio with an industrial edge: large sans-serif statements, compact monospaced labels, thin rules, and one acid-green accent. Keep the palette to the established neutral tokens and the tightly budgeted accent. Avoid ornamental cards, gradients, glow effects, and generic startup-dashboard styling.
+
+### Design Principles
+
+1. Make the proof scannable. A visitor should reach named outcomes and visible work evidence without hunting.
+2. Use space to clarify hierarchy. Keep related content tight, separate major sections generously, and remove whitespace that has no structural purpose.
+3. Preserve the editorial grid. Align text and rules precisely while allowing intentional asymmetry between the identity rail and the evidence column.
+4. Spend emphasis carefully. Reserve the acid-green accent for the defined headline, interaction, call-to-action, and chart-payoff roles.
+5. Keep every state accessible. Maintain the 12px text floor, visible focus treatment, 44px touch targets where needed, reduced-motion support, and responsive access to all content.

--- a/src/components/site/Rail.tsx
+++ b/src/components/site/Rail.tsx
@@ -10,8 +10,8 @@ export function Rail({ children }: RailProps) {
   const rest = tail.join(" ");
 
   return (
-    <div className="mx-auto grid min-h-screen max-w-[1440px] grid-cols-1 min-[900px]:grid-cols-[288px_minmax(0,1fr)]">
-      <header className="border-b border-border px-4 pb-0 pt-8 min-[360px]:px-5 min-[900px]:sticky min-[900px]:top-0 min-[900px]:col-start-1 min-[900px]:row-start-1 min-[900px]:grid min-[900px]:h-screen min-[900px]:grid-rows-[auto_minmax(0,1fr)_9rem] min-[900px]:overflow-y-auto min-[900px]:border-b-0 min-[900px]:border-r min-[900px]:p-11 min-[900px]:px-5">
+    <div className="grid min-h-screen grid-cols-1 min-[900px]:grid-cols-[288px_minmax(0,1fr)]">
+      <header className="border-b border-border px-4 pb-0 pt-8 min-[360px]:px-5 min-[900px]:sticky min-[900px]:top-0 min-[900px]:col-start-1 min-[900px]:row-start-1 min-[900px]:grid min-[900px]:h-screen min-[900px]:grid-rows-[auto_minmax(0,1fr)_9rem] min-[900px]:overflow-y-auto min-[900px]:border-b-0 min-[900px]:border-r min-[900px]:px-5 min-[900px]:py-11">
         <div>
           <p
             data-testid="profile-name"

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -290,6 +290,27 @@ test.describe("content evidence and navigation", () => {
 });
 
 test.describe("responsive layout", () => {
+  test("the desktop rail uses the same visible inset on both sides", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1600, height: 900 });
+    await page.goto("/");
+
+    const leftInset = await page.getByRole("banner").evaluate((element) => {
+      const style = getComputedStyle(element);
+      return (
+        element.getBoundingClientRect().left +
+        Number.parseFloat(style.paddingLeft)
+      );
+    });
+    const rightInset = await page.getByRole("contentinfo").evaluate((element) =>
+      Number.parseFloat(getComputedStyle(element).paddingRight),
+    );
+
+    expect(leftInset).toBe(rightInset);
+    expect(leftInset).toBe(20);
+  });
+
   test("the profile name stays on one line across rail layouts", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- Remove the centered 1440px shell gutter so the 288px identity rail begins at the viewport edge on wide screens.
- Keep the rail content at a symmetric 20px inset and make desktop vertical padding explicit.
- Add a rendered-style Playwright regression test and record the portfolio design context.

## Test plan
- [x] `CHOKIDAR_USEPOLLING=1 npm run test -- --reporter=dot` — 264 tests passed
- [x] `npm run lint`
- [x] `npm run build -- --webpack`
- [x] `npm run typecheck`
- [x] `npm run e2e` — 22 tests passed
- [x] Verify the 1600px layout: visible left inset is 20px and matches the rail right inset

## Review
- Three-model scoped review completed with no correctness, accessibility, or test blockers.
- The approved ultra-wide composition is intentional.